### PR TITLE
Add data directory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Platform | Windows | [Linux/BSDs](https://specifications.freedesktop.org/basedir
 User-specific config | `%APPDATA%` (`C:\Users\%USERNAME%\AppData\Roaming`) | `$XDG_CONFIG_HOME` (`$HOME/.config`) | `$HOME/Library/Application Support`
 User-specific cache | `%LOCALAPPDATA%` (`C:\Users\%USERNAME%\AppData\Local`) | `$XDG_CACHE_HOME` (`$HOME/.cache`) | `$HOME/Library/Caches`
 User-specific logs | `%LOCALAPPDATA%` (`C:\Users\%USERNAME%\AppData\Local`) | `$XDG_STATE_HOME` (`$HOME/.local/state`) | `$HOME/Library/Logs`
+User-specific data | `%LOCALAPPDATA%` (`C:\Users\%USERNAME%\AppData\Local`) | `$XDG_DATA_HOME` (`$HOME/.local/share`) | `$HOME/Library/Application Support`
 
 Inspired by [`configdir`](https://github.com/shibukawa/configdir).
 

--- a/appdir.go
+++ b/appdir.go
@@ -9,6 +9,8 @@ type Dirs interface {
 	UserCache() string
 	// Get the user-specific logs directory.
 	UserLogs() string
+	// Get the user-specific data directory.
+	UserData() string
 }
 
 // New creates a new App with the provided name.

--- a/appdir_darwin.go
+++ b/appdir_darwin.go
@@ -20,3 +20,7 @@ func (d *dirs) UserCache() string {
 func (d *dirs) UserLogs() string {
 	return filepath.Join(os.Getenv("HOME"), "Library", "Logs", d.name)
 }
+
+func (d *dirs) UserData() string {
+	return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", d.name)
+}

--- a/appdir_windows.go
+++ b/appdir_windows.go
@@ -20,3 +20,7 @@ func (d *dirs) UserCache() string {
 func (d *dirs) UserLogs() string {
 	return filepath.Join(os.Getenv("LOCALAPPDATA"), d.name)
 }
+
+func (d *dirs) UserData() string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), d.name)
+}

--- a/appdir_xdg.go
+++ b/appdir_xdg.go
@@ -37,3 +37,12 @@ func (d *dirs) UserLogs() string {
 
 	return filepath.Join(baseDir, d.name)
 }
+
+func (d *dirs) UserData() string {
+	baseDir := filepath.Join(os.Getenv("HOME"), ".local", "share")
+	if os.Getenv("XDG_DATA_HOME") != "" {
+		baseDir = os.Getenv("XDG_DATA_HOME")
+	}
+
+	return filepath.Join(baseDir, d.name)
+}


### PR DESCRIPTION
XDG platforms like Linux have `$XDG_DATA_HOME`, which is used to store required runtime application data. I added support for this for XDG platforms, but not OSX or windows, since I'm not familiar with those. I'm also not sure if those platforms have a similar construct, or if they wrap up that functionality into one of the already available application directories.