### PR TITLE
XDG: Directly return the default if present

### DIFF
--- a/appdir_xdg.go
+++ b/appdir_xdg.go
@@ -12,36 +12,36 @@ type dirs struct {
 }
 
 func (d *dirs) UserConfig() string {
-	baseDir := filepath.Join(os.Getenv("HOME"), ".config")
-	if d := os.Getenv("XDG_CONFIG_HOME"); d != "" {
-		baseDir = d
+	baseDir := os.Getenv("XDG_CONFIG_HOME")
+	if baseDir == "" {
+		baseDir = filepath.Join(os.Getenv("HOME"), ".config")
 	}
 
 	return filepath.Join(baseDir, d.name)
 }
 
 func (d *dirs) UserCache() string {
-	baseDir := filepath.Join(os.Getenv("HOME"), ".cache")
-	if d := os.Getenv("XDG_CACHE_HOME"); d != "" {
-		baseDir = d
+	baseDir := os.Getenv("XDG_CACHE_HOME")
+	if baseDir == "" {
+		baseDir = filepath.Join(os.Getenv("HOME"), ".cache")
 	}
 
 	return filepath.Join(baseDir, d.name)
 }
 
 func (d *dirs) UserLogs() string {
-	baseDir := filepath.Join(os.Getenv("HOME"), ".local", "state")
-	if d := os.Getenv("XDG_STATE_HOME"); d != "" {
-		baseDir = d
+	baseDir := os.Getenv("XDG_STATE_HOME")
+	if baseDir == "" {
+		baseDir = filepath.Join(os.Getenv("HOME"), ".local", "state")
 	}
 
 	return filepath.Join(baseDir, d.name)
 }
 
 func (d *dirs) UserData() string {
-	baseDir := filepath.Join(os.Getenv("HOME"), ".local", "share")
-	if d := os.Getenv("XDG_DATA_HOME"); d != "" {
-		baseDir = d
+	baseDir := os.Getenv("XDG_DATA_HOME")
+	if baseDir == "" {
+		baseDir = filepath.Join(os.Getenv("HOME"), ".local", "share")
 	}
 
 	return filepath.Join(baseDir, d.name)

--- a/appdir_xdg_test.go
+++ b/appdir_xdg_test.go
@@ -1,0 +1,162 @@
+package appdir
+
+import (
+	"os"
+	"testing"
+)
+
+func TestUserConfig(t *testing.T) {
+	if err := os.Setenv("HOME", "/home/user"); err != nil {
+		panic(err)
+	}
+
+	for _, tc := range [...]struct {
+		name          string
+		overrideValue string
+		expected      string
+	}{
+		{
+			name:     "default config directory",
+			expected: "/home/user/.config/app",
+		},
+		{
+			name:          "config directory set to absolute",
+			overrideValue: "/config",
+			expected:      "/config/app",
+		},
+		{
+			name:          "config directory set to relative",
+			overrideValue: "config",
+			expected:      "config/app",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := dirs{name: "app"}
+
+			if err := os.Setenv("XDG_CONFIG_HOME", tc.overrideValue); err != nil {
+				panic(err)
+			}
+
+			if have := d.UserConfig(); have != tc.expected {
+				t.Errorf("expected %q, found %q", tc.expected, have)
+			}
+		})
+	}
+}
+
+func TestUserCache(t *testing.T) {
+	if err := os.Setenv("HOME", "/home/user"); err != nil {
+		panic(err)
+	}
+
+	for _, tc := range [...]struct {
+		name          string
+		overrideValue string
+		expected      string
+	}{
+		{
+			name:     "default cache directory",
+			expected: "/home/user/.cache/app",
+		},
+		{
+			name:          "cache directory set to absolute",
+			overrideValue: "/cache",
+			expected:      "/cache/app",
+		},
+		{
+			name:          "cache directory set to relative",
+			overrideValue: "cache",
+			expected:      "cache/app",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := dirs{name: "app"}
+
+			if err := os.Setenv("XDG_CACHE_HOME", tc.overrideValue); err != nil {
+				panic(err)
+			}
+
+			if have := d.UserCache(); have != tc.expected {
+				t.Errorf("expected %q, found %q", tc.expected, have)
+			}
+		})
+	}
+}
+
+func TestUserLogs(t *testing.T) {
+	if err := os.Setenv("HOME", "/home/user"); err != nil {
+		panic(err)
+	}
+
+	for _, tc := range [...]struct {
+		name          string
+		overrideValue string
+		expected      string
+	}{
+		{
+			name:     "default logs directory",
+			expected: "/home/user/.local/state/app",
+		},
+		{
+			name:          "logs directory set to absolute",
+			overrideValue: "/logs",
+			expected:      "/logs/app",
+		},
+		{
+			name:          "logs directory set to relative",
+			overrideValue: "logs",
+			expected:      "logs/app",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := dirs{name: "app"}
+
+			if err := os.Setenv("XDG_STATE_HOME", tc.overrideValue); err != nil {
+				panic(err)
+			}
+
+			if have := d.UserLogs(); have != tc.expected {
+				t.Errorf("expected %q, found %q", tc.expected, have)
+			}
+		})
+	}
+}
+
+func TestUserData(t *testing.T) {
+	if err := os.Setenv("HOME", "/home/user"); err != nil {
+		panic(err)
+	}
+
+	for _, tc := range [...]struct {
+		name          string
+		overrideValue string
+		expected      string
+	}{
+		{
+			name:     "default data directory",
+			expected: "/home/user/.local/share/app",
+		},
+		{
+			name:          "data directory set to absolute",
+			overrideValue: "/data",
+			expected:      "/data/app",
+		},
+		{
+			name:          "data directory set to relative",
+			overrideValue: "data",
+			expected:      "data/app",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := dirs{name: "app"}
+
+			if err := os.Setenv("XDG_DATA_HOME", tc.overrideValue); err != nil {
+				panic(err)
+			}
+
+			if have := d.UserData(); have != tc.expected {
+				t.Errorf("expected %q, found %q", tc.expected, have)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This cosmetic change (aka "refactoring") avoids path computation if the
variable is present in the environment.

From https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html :

> If $XDG_CONFIG_HOME is either not set or empty, a default equal to
> $HOME/.config should be used.

In order to better reflect the specification in the code, fetch the
environment variable first.

_**Bonus**: every refactoring requires some tests._